### PR TITLE
Solve the bug that output txt file shows only in 1 line in Summary and Save use cases.

### DIFF
--- a/src/data_access/FileSaveDataAccessObject.java
+++ b/src/data_access/FileSaveDataAccessObject.java
@@ -5,9 +5,12 @@ import use_case.save.SaveUserDataAccessInterface;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class FileSaveDataAccessObject implements SaveUserDataAccessInterface {
     public FileSaveDataAccessObject(){};
+
     public static void saveStringToFile(String content, String filePath) throws IOException {
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
             writer.write(content);
@@ -16,16 +19,36 @@ public class FileSaveDataAccessObject implements SaveUserDataAccessInterface {
             e.printStackTrace();
         }
     }
+
     @Override
     public void saveMessage(String savedMessage) {
-        String filePath = "savedMessage.txt";
+        String formattedMessage = formatMessageWithLineBreaks(savedMessage, 110);
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
+        String filePath = "savedMessage_" + timestamp + ".txt";
 
         try {
-            saveStringToFile(savedMessage, filePath);
+            saveStringToFile(formattedMessage, filePath);
             System.out.println("Content saved to file: " + filePath);
         } catch (IOException e) {
             System.err.println("An error occurred while saving the file.");
             e.printStackTrace();
         }
+    }
+
+    private String formatMessageWithLineBreaks(String message, int lineLength) {
+        StringBuilder formattedMessage = new StringBuilder();
+        int counter = 0;
+
+        for (char ch : message.toCharArray()) {
+            if (counter >= lineLength && ch == ' ') {
+                formattedMessage.append('\n');
+                counter = 0;
+            } else {
+                formattedMessage.append(ch);
+                counter++;
+            }
+        }
+
+        return formattedMessage.toString();
     }
 }

--- a/src/data_access/FileSummayDataAccessObject.java
+++ b/src/data_access/FileSummayDataAccessObject.java
@@ -3,9 +3,10 @@ package data_access;
 import use_case.summary.SummaryUserDataAccessInterface;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class FileSummayDataAccessObject implements SummaryUserDataAccessInterface {
     public FileSummayDataAccessObject(){};
@@ -20,15 +21,33 @@ public class FileSummayDataAccessObject implements SummaryUserDataAccessInterfac
 
     @Override
     public void saveSummary(String summary) {
-        String filePath = "summary.txt";
+        String formattedMessage = formatMessageWithLineBreaks(summary, 110);
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
+        String filePath = "summary_" + timestamp + ".txt";
 
         try {
-            saveStringToFile(summary, filePath);
+            saveStringToFile(formattedMessage, filePath);
             System.out.println("Content saved to file: " + filePath);
         } catch (IOException e) {
             System.err.println("An error occurred while saving the file.");
             e.printStackTrace();
         }
+    }
 
+    private String formatMessageWithLineBreaks(String message, int lineLength) {
+        StringBuilder formattedMessage = new StringBuilder();
+        int counter = 0;
+
+        for (char ch : message.toCharArray()) {
+            if ((counter >= lineLength && ch == ' ') || counter >= lineLength + 10) {
+                formattedMessage.append('\n');
+                counter = 0;
+            } else {
+                formattedMessage.append(ch);
+                counter++;
+            }
+        }
+
+        return formattedMessage.toString();
     }
 }

--- a/src/interface_adapter/UserCreationFailed.java
+++ b/src/interface_adapter/UserCreationFailed.java
@@ -1,7 +1,0 @@
-package interface_adapter;
-
-public class UserCreationFailed extends RuntimeException {
-    public UserCreationFailed(String error) {
-        super(error);
-    }
-}


### PR DESCRIPTION
I modify the two save methods separetly in save use case and summary use case, now they can be saved lines by lines, instead of just in one line, and the file name will be related to the real-time time, which help for human viewing.